### PR TITLE
Bug fixes associated with readBatch() and writeBatch()

### DIFF
--- a/src/main/scala/pixii/Table.scala
+++ b/src/main/scala/pixii/Table.scala
@@ -241,7 +241,9 @@ trait TableOperations[K,  V] { self: Table[V] =>
       requests.clear()
       requests.addAll(unprocessed)
       requests.addAll(toAppend)
-      val response = dynamoDB.batchWriteItem(request)
+      val response = retryPolicy.retry("Table(%s).writeAll" format tableName) {
+        dynamoDB.batchWriteItem(request)
+      }
       val unprocessedItems = Option(response.getUnprocessedItems()) flatMap (m => Option(m.get(tableName)))
       if (unprocessedItems.isEmpty) {
         (requests.size, java.util.Collections.emptyList[WriteRequest](), remaining drop toAppend.size)
@@ -257,13 +259,11 @@ trait TableOperations[K,  V] { self: Table[V] =>
       override def hasRemainingOperations = pending.nonEmpty || !unprocessed.isEmpty
       override def submitMoreOperations() = {
         if (!hasRemainingOperations) throw new NoSuchElementException
-        retryPolicy.retry("Table(%s).writeAll" format tableName) {
-          val (written, stillUnprocessed, stillPending) = nextSubmission(unprocessed, pending)
-          completedOperations += written
-          unprocessed = stillUnprocessed
-          pending = stillPending
-          written
-        }
+        val (written, stillUnprocessed, stillPending) = nextSubmission(unprocessed, pending)
+        completedOperations += written
+        unprocessed = stillUnprocessed
+        pending = stillPending
+        written
       }
 
     }

--- a/src/main/scala/pixii/fake/FakeDynamoDB.scala
+++ b/src/main/scala/pixii/fake/FakeDynamoDB.scala
@@ -123,10 +123,12 @@ class FakeDynamo extends AmazonDynamoDB {
     val responses = mutable.Map[String, java.util.List[java.util.Map[String, AttributeValue]]]()
     for ((tableName, keysAndAttributes) <- requests) {
       val table = getTable(tableName)
-      val items = for (key <- keysAndAttributes.getKeys) yield {
-        table.getItem(new GetItemRequest().withKey(key)).getItem()
-      }
-      responses += tableName -> items
+      val items = for {
+        key <- keysAndAttributes.getKeys
+        item <- table.getItemOpt(new GetItemRequest().withKey(key))
+      } yield item.getItem()
+      if (items.nonEmpty)
+        responses += tableName -> items
     }
     new BatchGetItemResult().withResponses(responses)
   }
@@ -166,6 +168,7 @@ abstract class FakeTable(
   var provisionedThroughput: ProvisionedThroughput) {
   val creationDateTime = new java.util.Date
   def getItem(getItemRequest: GetItemRequest): GetItemResult
+  def getItemOpt(getItemRequest: GetItemRequest): Option[GetItemResult]
   def putItem(putItemRequest: PutItemRequest): PutItemResult
   def deleteItem(deleteItemRequest: DeleteItemRequest): DeleteItemResult
   def updateItem(updateItemRequest: UpdateItemRequest): UpdateItemResult
@@ -296,12 +299,16 @@ class FakeTableWithHashKey(
 
   def getItem(getItemRequest: GetItemRequest): GetItemResult = {
     val key = getItemRequest.getKey
-    val item = items.get(key) getOrElse { throw new ResourceNotFoundException("Item not found: " + key) }
-    new GetItemResult().withItem(item)
+    getItemOpt(getItemRequest) getOrElse { throw new ResourceNotFoundException("Item not found: " + key) }
+  }
+
+  def getItemOpt(getItemRequest: GetItemRequest): Option[GetItemResult] = {
+    val key = getItemRequest.getKey
+    items.get(key) map (new GetItemResult().withItem(_))
   }
 
   def putItem(putItemRequest: PutItemRequest): PutItemResult = {
-    val key = putItemRequest.getItem
+    val key = putItemRequest.getItem.filterKeys(k => keySchema.exists(k == _.getAttributeName))
     val item = items.getOrElseUpdate(key, mutable.Map())
     item.clear()
     item ++= putItemRequest.getItem
@@ -352,11 +359,14 @@ class FakeTableWithHashRangeKey(
 
   def getItem(getItemRequest: GetItemRequest): GetItemResult = {
     val key = getItemRequest.getKey
+    getItemOpt(getItemRequest) getOrElse { throw new ResourceNotFoundException("Item not found: " + key) }
+  }
+
+  def getItemOpt(getItemRequest: GetItemRequest): Option[GetItemResult] = {
+    val key = getItemRequest.getKey
     val hashKey = keySchema.filter(_.getKeyType == KeyTypes.Hash.code).get(0).getAttributeName()
     val rangeKey = keySchema.filter(_.getKeyType == KeyTypes.Range.code).get(0).getAttributeName()
-    val range = items.get(key(hashKey)) getOrElse { throw new ResourceNotFoundException("Item not found: " + key) }
-    val item = range.get(key(rangeKey)) getOrElse { throw new ResourceNotFoundException("Item not found: " + key) }
-    new GetItemResult().withItem(item)
+    items.get(key(hashKey)) flatMap (_.get(key(rangeKey))) map (new GetItemResult().withItem(_))
   }
 
   def putItem(putItemRequest: PutItemRequest): PutItemResult = {


### PR DESCRIPTION
- Fixed a bug in pixii.Table that would cause elements of the input
  iterator to be skipped in writeBatch() if an exception triggered the
  retry policy.
- Fixed a bug in pixii.fake.FakeDynamoDb that was incorrectly throwing
  exceptions when an item in a batch get request was not found.
- Fixed a bug in pixii.fake.FakeTableWithHashKey that was causing
  elements to be stored under the wrong key when inserted using putItem().
