### PR TITLE
Refactor iterator setup, add queryCount + scanCount

### DIFF
--- a/src/main/scala/pixii/iterators.scala
+++ b/src/main/scala/pixii/iterators.scala
@@ -1,0 +1,46 @@
+package pixii
+
+package object iterators {
+  /**
+   * A generic "paging" iterator that abstracts out DynamoDB's pagination behavior.  When DynamoDB returns a response,
+   * it specifies a `LastEvaluatedKey` if the available results are unable to be returned in a single page.  The
+   * `LastEvaluatedKey` can then be passed into a subsequent request to continue paging through available results.
+   *
+   * See docs for more detail:
+   * http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Pagination
+   */
+  class PagingIterator[PaginationKey, PagedResponse](
+    operationName: String,
+    getNextPage: Option[PaginationKey] => (PagedResponse, Option[PaginationKey]),
+    retryPolicy: RetryPolicy
+  ) extends Iterator[PagedResponse] {
+    private var page: Option[PagedResponse] = None
+    private var exclusiveStartKey: Option[PaginationKey] = None
+    private var morePages = true
+
+    override def hasNext = synchronized {
+      if (page.isEmpty && morePages) loadNextPage()
+
+      (exclusiveStartKey.nonEmpty || page.nonEmpty)
+    }
+
+    override def next(): PagedResponse = synchronized {
+      if (!hasNext) throw new IllegalStateException("hasNext is false")
+
+      val previousPage = page.get
+      page = None
+      previousPage
+    }
+
+    private def loadNextPage() = {
+      retryPolicy.retry(operationName) {
+        val (nextPage, nextExclusiveStartKey) = getNextPage(exclusiveStartKey)
+        if (nextExclusiveStartKey.isEmpty) {
+          morePages = false
+        }
+        exclusiveStartKey = nextExclusiveStartKey
+        page = Some(nextPage)
+      }
+    }
+  }
+}

--- a/src/test/scala/pixii/IteratorsSuite.scala
+++ b/src/test/scala/pixii/IteratorsSuite.scala
@@ -1,0 +1,69 @@
+package pixii
+
+import org.scalatest.WordSpec
+import org.scalatest.matchers.ShouldMatchers
+import pixii.iterators._
+
+@org.junit.runner.RunWith(classOf[org.scalatest.junit.JUnitRunner])
+class IteratorsSuite extends WordSpec with ShouldMatchers {
+  "PagingIterator" should {
+    "initialize with a lazy head" in {
+      val service = new MockService(1)
+      val iterator = new PagingIterator("test", getNextPage(service), NoRetry)
+
+      service.timesCalled should be (0)
+    }
+
+    "be lazy when pulling data" in {
+      val service = new MockService(5)
+      val iterator = new PagingIterator("test", getNextPage(service), NoRetry)
+
+      iterator.take(2).to[Vector] should be (Vector("x", "x"))
+      service.timesCalled should be (2)
+    }
+
+    "return all elements when exhausting the underlying data source" in {
+      val service = new MockService(5)
+      val iterator = new PagingIterator("test", getNextPage(service), NoRetry)
+
+      iterator.to[Vector] should be (Vector("x", "x", "x", "x", "x"))
+      service.timesCalled should be (5)
+    }
+  }
+
+  private def getNextPage(service: MockService) = { (key: Option[Int]) =>
+    service.call(key)
+  }
+
+  /**
+   * A service that emulates a generic paginated api.  Returns paged responses of "x" up to `numPages` pages.  e.g.:
+   *
+   * ```
+   * val service1 = new MockService(1)
+   * service1.call(None) // => ("x", None)
+   *
+   * val service2 = new MockService(2)
+   * service2.call(None) // => ("x", Some(1))
+   * service2.call(Some(1)) // => ("x", None)
+   * ```
+   */
+  private class MockService(numPages: Int) {
+    type PaginationKey = Int
+    type Response = String
+
+    var timesCalled = 0
+
+    def call(pageKey: Option[PaginationKey]): (Response, Option[PaginationKey]) = {
+      timesCalled += 1
+      val key = pageKey.getOrElse(0)
+
+      if (key == numPages - 1) {
+        ("x", None)
+      } else if (key > numPages - 1) {
+        throw new Exception("Exceeded max items!")
+      } else {
+        ("x", Some(key + 1))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Main changes:
- Replace old `iterator` implementation in `Table` by separating the handling of pagination with the extraction of individual result items.  Also compose this iterator via `map`/etc instead of wrapping inside new iterator.
- Extract query + scan request building to their own methods for easier re-use.
- Implement `queryCount` + `scanCount` methods.  These should be basically the same as `query` + `scan`, with the addition of `withSelect(Select.COUNT)`.
